### PR TITLE
165 setup libraries requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ conda activate colibri
 3. Install the requirements:
 
 ```bash
-pip install -r requirements.txt
+pip install .
 ```
 
 4. Enjoy! 😄

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-tqdm
-h5py
-matplotlib
-torch
-torchvision
-torchmetrics
-requests

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,14 @@ from setuptools import setup
 
 setup(
     name='colibri',
-    install_requires=['torch', 'torchmetrics', 'tqdm', 'torchvision', 'matplotlib', 'h5py', 'torch_dct', 'requests'],
+    install_requires=['torch>=1.13.0', 
+                      'torchmetrics>=0.11.4', 
+                      'tqdm>=4.66.5', 
+                      'torchvision>=0.14.0', 
+                      'matplotlib>=3.9.2', 
+                      'h5py>=3.12.1', 
+                      'torch_dct>=0.1.6', 
+                      'requests>=2.32.3'],
     extras_require={'doc': ['sphinx', 'sphinx_rtd_theme', 'autodocsumm', 'sphinx_gallery'],
                     'test': ['pytest']}
 )


### PR DESCRIPTION
Minor changes:

- [x] Include versions for dependencies in setup.py.
- [x] Delete the requirements.txt file.
- [x] Update the dependencies installation instructions.

By default, calling `pip install .` will check the dependencies in setup.py listed under `install_requires`. For extras, the command `pip install .[test]` can be used, for example.